### PR TITLE
Dockerize CI

### DIFF
--- a/.ci_build.sh
+++ b/.ci_build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+export BUILD_DIR="/${SOURCE_DIR}/build"
+
+cd "${SOURCE_DIR}"
+rm -Rf "${BUILD_DIR}"
+meson "${BUILD_DIR}"
+
+cd "${BUILD_DIR}"
+ninja
+ninja -C "${BUILD_DIR}" test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
+sudo: required
+
 language:
     - csharp
 
+services:
+    docker
+
 before_install:
-    - sudo apt-get install -y git python3-pip unzip build-essential libgtk-3-dev
-    - sudo apt-get build-dep -y libgtk-3-0
-    - wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
-    - unzip ninja-linux.zip
-    - sudo mv ninja /usr/bin/
-    - sudo pip3 install git+https://github.com/mesonbuild/meson/
+    - docker build -t gtk-sharp-debian9 .
 
 script:
-    - meson build/ && ninja -C build/ test
+    - docker run gtk-sharp-debian9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:9
+
+RUN apt-get update && \
+    apt-get install -y git python3 python3-pip ninja-build mono-devel libgtk-3-dev
+
+RUN pip3 install git+https://github.com/mesonbuild/meson/
+
+ENV SOURCE_DIR="/source"
+
+RUN mkdir -p "${SOURCE_DIR}"
+
+COPY / "${SOURCE_DIR}"
+
+CMD ["/source/.ci_build.sh"]

--- a/dbuild.sh
+++ b/dbuild.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+docker build -t gtk-sharp-debian9 .
+
+docker run gtk-sharp-debian9 ${@}


### PR DESCRIPTION
Switches CI over to use Debian 9 based Docker image, allowing us build against later version of GTK.