### PR TITLE
Meson: Use shared_library() because static build of C# is not supported

### DIFF
--- a/Source/atk/meson.build
+++ b/Source/atk/meson.build
@@ -21,7 +21,7 @@ sources = [
     'Util.cs',
 ]
 
-atk_sharp = library(assembly_name, source_gen, sources, assemblyinfo,
+atk_sharp = shared_library(assembly_name, source_gen, sources, assemblyinfo,
         cs_args: ['-unsafe'],
         link_with: glib_sharp,
         install: install,

--- a/Source/cairo/meson.build
+++ b/Source/cairo/meson.build
@@ -60,7 +60,7 @@ sources = [
     'XlibSurface.cs',
 ]
 
-cairo_sharp = library(assembly_name, sources, assemblyinfo,
+cairo_sharp = shared_library(assembly_name, sources, assemblyinfo,
         install: install,
         install_dir: lib_install_dir
 )

--- a/Source/gdk/meson.build
+++ b/Source/gdk/meson.build
@@ -63,7 +63,7 @@ sources = [
 ]
 
 deps = [glib_sharp, pango_sharp, cairo_sharp, gio_sharp]
-gdk_sharp = library(assembly_name, source_gen, sources, assemblyinfo,
+gdk_sharp = shared_library(assembly_name, source_gen, sources, assemblyinfo,
         cs_args: ['-unsafe'],
         link_with: deps,
         install: install,

--- a/Source/gio/meson.build
+++ b/Source/gio/meson.build
@@ -28,7 +28,7 @@ sources = [
     'IFile.cs'
 ]
 
-gio_sharp = library(assembly_name, source_gen, sources, assemblyinfo,
+gio_sharp = shared_library(assembly_name, source_gen, sources, assemblyinfo,
         cs_args: ['-unsafe'],
         link_with: glib_sharp,
         install: install,

--- a/Source/glib/meson.build
+++ b/Source/glib/meson.build
@@ -95,7 +95,7 @@ sources = [
     'VariantType.cs']
 
 
-glib_sharp = library(assembly_name, sources, assemblyinfo,
+glib_sharp = shared_library(assembly_name, sources, assemblyinfo,
         cs_args: ['-unsafe'],
         install: install,
         install_dir: lib_install_dir

--- a/Source/gtk/meson.build
+++ b/Source/gtk/meson.build
@@ -132,7 +132,7 @@ sources = [
 ]
 
 deps = [glib_sharp, pango_sharp, cairo_sharp, gio_sharp, atk_sharp, gdk_sharp]
-gtk_sharp = library(assembly_name, source_gen, sources, assemblyinfo,
+gtk_sharp = shared_library(assembly_name, source_gen, sources, assemblyinfo,
         cs_args: ['-unsafe', '-nowarn:0618,0612,0169'],
         link_with: deps,
         install: install,

--- a/Source/pango/meson.build
+++ b/Source/pango/meson.build
@@ -57,7 +57,7 @@ sources = [
 ]
 
 deps = [glib_sharp, cairo_sharp]
-pango_sharp = library(assembly_name, source_gen, sources, assemblyinfo,
+pango_sharp = shared_library(assembly_name, source_gen, sources, assemblyinfo,
         cs_args: ['-unsafe'],
         link_with: deps,
         install: install,


### PR DESCRIPTION
When gtk-sharp is used as a subproject (e.g. gst-build) and the master
project is built with default-library=both, gtk-sharp should still only
build shared libraries instead of failing to configure.