### PR TITLE
Problem with Ubuntu 16.04 - Gtk Sharp 3 can't build...

### DIFF
--- a/Source/meson.build
+++ b/Source/meson.build
@@ -55,7 +55,7 @@ assembly_data.set('API_VERSION', apiversion)
 assemblyinfo = configure_file(input: 'AssemblyInfo.cs.in', output: 'AssemblyInfo.cs', configuration : assembly_data)
 
 policy_config = files('policy.config.in')
-if host_machine.system() == 'osx'
+if host_machine.system() == 'darwin'
   lib_prefix=''
   lib_suffix='.dylib'
 else


### PR DESCRIPTION
I have already tried meson build

```
Native dependency gdk-3.0 found: NO found '3.18.9' but need: '>=3.22.0'
Dependency gdk-3.0 found: NO
Message: Gdk not found, not building
Native dependency gtk+-3.0 found: NO found '3.18.9' but need: '>=3.22.0'
Dependency gtk+-3.0 found: NO
```

I already tried to install sudo apt install -fy libgtk-3-dev libgdk-3-dev but meson doesn't know where are installed dependencies...

How do I fix?