### PR TITLE
ValueArray: Create copy when receiving pointer

### DIFF
--- a/Source/glib/ValueArray.cs
+++ b/Source/glib/ValueArray.cs
@@ -43,7 +43,7 @@ namespace GLib {
 
 		public ValueArray (IntPtr raw)
 		{
-			handle = raw;
+			handle = g_value_array_copy (raw);
 		}
 		
 		~ValueArray ()


### PR DESCRIPTION
The "ref" operation of GValueArray is a copy, so we don't have a choice.

I can reproduce by parsing a large number of messages from the "level" element and getting the "peak" out, if I do it fast enough (like with "audiotestsrc ! level ! fakesink"), it crashes.

I made the matching PR to the mono repo:
https://github.com/mono/gtk-sharp/pull/260