### PR TITLE
build: on Windows, use MSVC format for glib, gio and gobject dlls

### DIFF
--- a/Source/atk/atk-sharp.dll.config.in
+++ b/Source/atk/atk-sharp.dll.config.in
@@ -1,4 +1,4 @@
 <configuration>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="gobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libatk-1.0-0.dll" target="libatk-1.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
 </configuration>

--- a/Source/doc/en/GLib/Object.xml
+++ b/Source/doc/en/GLib/Object.xml
@@ -228,7 +228,7 @@ This method is called by the generated classes by the Gtk# framework.
     </Member>
     <Member MemberName="g_signal_chain_from_overridden">
       <MemberSignature Language="C#" Value="protected static void g_signal_chain_from_overridden (IntPtr args, ref GLib.Value retval);" />
-      <MemberSignature Language="ILAsm" Value=".method familystatic hidebysig pinvokeimpl (&quot;libgobject-2.0-0.dll&quot; as &quot;g_signal_chain_from_overridden&quot; cdecl)void g_signal_chain_from_overridden(native int args, valuetype GLib.Value retval) cil managed" />
+      <MemberSignature Language="ILAsm" Value=".method familystatic hidebysig pinvokeimpl (&quot;gobject-2.0-0.dll&quot; as &quot;g_signal_chain_from_overridden&quot; cdecl)void g_signal_chain_from_overridden(native int args, valuetype GLib.Value retval) cil managed" />
       <MemberType>Method</MemberType>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>

--- a/Source/gdk/PixbufLoader.cs
+++ b/Source/gdk/PixbufLoader.cs
@@ -28,7 +28,7 @@ namespace Gdk {
 
 	public partial class PixbufLoader {
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("gobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr g_object_ref (IntPtr handle);
 
 		internal IntPtr PixbufHandle {

--- a/Source/gdk/Window.cs
+++ b/Source/gdk/Window.cs
@@ -77,7 +77,7 @@ namespace Gdk {
 			}
 		}
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("gobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr g_object_ref (IntPtr raw);
 
 		[DllImport (Global.GdkNativeDll, CallingConvention = CallingConvention.Cdecl)]

--- a/Source/gdk/gdk-sharp.dll.config.in
+++ b/Source/gdk/gdk-sharp.dll.config.in
@@ -1,7 +1,7 @@
 <configuration>
-  <dllmap dll="libgio-2.0-0.dll" target="libgio-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="gio-2.0-0.dll" target="libgio-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="glib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="gobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libgdk-3-0.dll" target="libgdk-3@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libgdk_pixbuf-2.0-0.dll" target="libgdk_pixbuf-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
 </configuration>

--- a/Source/gio/GioGlobal.cs
+++ b/Source/gio/GioGlobal.cs
@@ -24,6 +24,6 @@ namespace GLib
 {
 	public partial class GioGlobal
 	{
-		internal const string GioNativeDll = "libgio-2.0-0.dll";
+		internal const string GioNativeDll = "gio-2.0-0.dll";
 	}
 }

--- a/Source/gio/gio-api.raw
+++ b/Source/gio/gio-api.raw
@@ -6,7 +6,7 @@
         Please DO NOT MODIFY THIS FILE, modify .metadata files instead.
 
 -->
-  <namespace name="G" library="libgio-2.0-0.dll">
+  <namespace name="G" library="gio-2.0-0.dll">
     <enum name="AppInfoCreateFlags" cname="GAppInfoCreateFlags" gtype="g_app_info_create_flags_get_type" type="flags">
       <member cname="G_APP_INFO_CREATE_NONE" name="None" />
       <member cname="G_APP_INFO_CREATE_NEEDS_TERMINAL" name="NeedsTerminal" value="1 &lt;&lt; 0" />

--- a/Source/gio/gio-sharp.dll.config.in
+++ b/Source/gio/gio-sharp.dll.config.in
@@ -1,5 +1,5 @@
 <configuration>
-  <dllmap dll="libgio-2.0-0.dll" target="libgio-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="gio-2.0-0.dll" target="libgio-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="glib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="gobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
 </configuration>

--- a/Source/glib/Global.cs
+++ b/Source/glib/Global.cs
@@ -31,8 +31,8 @@ namespace GLib {
 		//this is a static class
 		private Global () {}
 
-		internal const string GLibNativeDll = "libglib-2.0-0.dll";
-		internal const string GObjectNativeDll = "libgobject-2.0-0.dll";
+		internal const string GLibNativeDll = "glib-2.0-0.dll";
+		internal const string GObjectNativeDll = "gobject-2.0-0.dll";
 
 		internal static bool IsWindowsPlatform {
 			get {

--- a/Source/glib/glib-api.xml
+++ b/Source/glib/glib-api.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <api>
-  <namespace name="GLib" library="libglib-2.0-0.dll">
+  <namespace name="GLib" library="glib-2.0-0.dll">
     <enum name="ConnectFlags" cname="GConnectFlags" type="flags" />
     <enum name="IOCondition" cname="GIOCondition" type="enum" />
     <enum name="SeekType" cname="GSeekType" type="enum" />

--- a/Source/glib/glib-sharp.dll.config.in
+++ b/Source/glib/glib-sharp.dll.config.in
@@ -1,4 +1,4 @@
 <configuration>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="glib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="gobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
 </configuration>

--- a/Source/gtk/Adjustment.cs
+++ b/Source/gtk/Adjustment.cs
@@ -42,10 +42,10 @@ namespace Gtk {
 			Raw = gtk_adjustment_new(value, lower, upper, step_increment, page_increment, page_size);
 		}
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("gobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern void g_object_freeze_notify (IntPtr inst);
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("gobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern void g_object_thaw_notify (IntPtr inst);
 
 		public void SetBounds (double lower, double upper, double step_increment, double page_increment, double page_size)

--- a/Source/gtk/Widget.cs
+++ b/Source/gtk/Widget.cs
@@ -58,10 +58,10 @@ namespace Gtk {
 		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
 		delegate void ClosureMarshal (IntPtr closure, IntPtr return_val, uint n_param_vals, IntPtr param_values, IntPtr invocation_hint, IntPtr marshal_data);
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("gobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr g_closure_new_simple (int closure_size, IntPtr dummy);
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("gobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern void g_closure_set_marshal (IntPtr closure, ClosureMarshal marshaler);
 
 		static IntPtr CreateClosure (ClosureMarshal marshaler) {
@@ -70,7 +70,7 @@ namespace Gtk {
 			return raw_closure;
 		}
 
-		[DllImport ("libgobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("gobject-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern uint g_signal_newv (IntPtr signal_name, IntPtr gtype, GLib.Signal.Flags signal_flags, IntPtr closure, IntPtr accumulator, IntPtr accu_data, IntPtr c_marshaller, IntPtr return_type, uint n_params, [MarshalAs (UnmanagedType.LPArray)] IntPtr[] param_types);
 
 		static uint RegisterSignal (string signal_name, GLib.GType gtype, GLib.Signal.Flags signal_flags, GLib.GType return_type, GLib.GType[] param_types, ClosureMarshal marshaler)

--- a/Source/gtk/gtk-sharp.dll.config.in
+++ b/Source/gtk/gtk-sharp.dll.config.in
@@ -1,6 +1,6 @@
 <configuration>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="glib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="gobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libatk-1.0-0.dll" target="libatk-1.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libgtk-3-0.dll" target="libgtk-3@LIB_PREFIX@.0@LIB_SUFFIX@"/>
 </configuration>

--- a/Source/pango/ScriptIter.cs
+++ b/Source/pango/ScriptIter.cs
@@ -49,7 +49,7 @@ namespace Pango {
 		[DllImport ("libpango-1.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern void pango_script_iter_get_range (IntPtr raw, out IntPtr start, out IntPtr end, out Pango.Script script);
 
-		[DllImport ("libglib-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
+		[DllImport ("glib-2.0-0.dll", CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr g_utf8_pointer_to_offset (IntPtr str, IntPtr pos);
 
 		public void GetRange (out int start, out int len, out Pango.Script script)

--- a/Source/pango/pango-sharp.dll.config.in
+++ b/Source/pango/pango-sharp.dll.config.in
@@ -1,6 +1,6 @@
 <configuration>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="glib-2.0-0.dll" target="libglib-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
+  <dllmap dll="gobject-2.0-0.dll" target="libgobject-2.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libpango-1.0-0.dll" target="libpango-1.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
   <dllmap dll="libpangocairo-1.0-0.dll" target="libpangocairo-1.0@LIB_PREFIX@.0@LIB_SUFFIX@"/>
 </configuration>

--- a/Source/sources/sources.xml
+++ b/Source/sources/sources.xml
@@ -1,6 +1,6 @@
 <gapi-parser-input>
   <api filename="../gio/gio-api.raw">
-    <library name="libgio-2.0-0.dll">
+    <library name="gio-2.0-0.dll">
       <namespace name="G">
         <directory path="glib-2.50.2/gio">
           <exclude>gasynchelper.h</exclude>


### PR DESCRIPTION
See https://gitlab.freedesktop.org/gstreamer/gstreamer-sharp/issues/19 for more details on why we need to make these changes.