### PR TITLE
Prevent double removal of timeout sources

### DIFF
--- a/Source/glib/Idle.cs
+++ b/Source/glib/Idle.cs
@@ -54,7 +54,7 @@ namespace GLib {
 					{
 						lock (this)
 						{
-							Remove ();
+							Dispose ();
 						}
 					}
 					return cont;

--- a/Source/glib/Timeout.cs
+++ b/Source/glib/Timeout.cs
@@ -52,7 +52,7 @@ namespace GLib {
 					{
 						lock (this)
 						{
-							Remove ();
+							Dispose ();
 						}
 					}
 					return cont;


### PR DESCRIPTION
When a timeout source is scheduled for removal by returning false
from its handler, doing just Remove() on SourceProxy is not enough,
because it doesn't prevent g_source_remove() from eventually getting
called from SourceProxy's finalizer, effectively removing the same
Source ID twice.

Replacing Remove() with Dispose() fixes the double removal and the
accompanying "Source ID XX was not found when attempting to remove it"
GLib critical.