### PR TITLE
Opaque: allow immediate run of finalize handler

### DIFF
--- a/Source/atk/generated/Atk_Range.cs
+++ b/Source/atk/generated/Atk_Range.cs
@@ -104,7 +104,11 @@ namespace Atk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gdk/generated/Gdk_FrameTimings.cs
+++ b/Source/gdk/generated/Gdk_FrameTimings.cs
@@ -132,7 +132,11 @@ namespace Gdk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gdk/generated/Gdk_PixbufFormat.cs
+++ b/Source/gdk/generated/Gdk_PixbufFormat.cs
@@ -166,7 +166,11 @@ namespace Gdk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/generator/OpaqueGen.cs
+++ b/Source/generator/OpaqueGen.cs
@@ -167,7 +167,11 @@ namespace GtkSharp.Generation {
 				sw.WriteLine ("\t\t\tif (!Owned)");
 				sw.WriteLine ("\t\t\t\treturn;");
 				sw.WriteLine ("\t\t\tFinalizerInfo info = new FinalizerInfo (Handle);");
-				sw.WriteLine ("\t\t\tGLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));");
+				sw.WriteLine ("\t\t\tif (ForceFinalizeInMainThread) {");
+				sw.WriteLine ("\t\t\t\tGLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));");
+				sw.WriteLine ("\t\t\t} else {");
+				sw.WriteLine ("\t\t\t\tinfo.Handler();");
+				sw.WriteLine ("\t\t\t}");
 				sw.WriteLine ("\t\t}");
 				sw.WriteLine ();
 			}

--- a/Source/gio/generated/GLib_FileAttributeInfoList.cs
+++ b/Source/gio/generated/GLib_FileAttributeInfoList.cs
@@ -103,7 +103,11 @@ namespace GLib {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gio/generated/GLib_FileAttributeMatcher.cs
+++ b/Source/gio/generated/GLib_FileAttributeMatcher.cs
@@ -136,7 +136,11 @@ namespace GLib {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gio/generated/GLib_IOModuleScope.cs
+++ b/Source/gio/generated/GLib_IOModuleScope.cs
@@ -58,7 +58,11 @@ namespace GLib {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gio/generated/GLib_Resource.cs
+++ b/Source/gio/generated/GLib_Resource.cs
@@ -152,7 +152,11 @@ namespace GLib {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gio/generated/GLib_SrvTarget.cs
+++ b/Source/gio/generated/GLib_SrvTarget.cs
@@ -124,7 +124,11 @@ namespace GLib {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/glib/Opaque.cs
+++ b/Source/glib/Opaque.cs
@@ -30,6 +30,8 @@ namespace GLib {
 
 	public class Opaque : IWrapper, IDisposable {
 
+		public static bool ForceFinalizeInMainThread = true;
+
 		IntPtr _obj;
 		bool owned;
 

--- a/Source/gtk/generated/Gtk_CssSection.cs
+++ b/Source/gtk/generated/Gtk_CssSection.cs
@@ -143,7 +143,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_Gradient.cs
+++ b/Source/gtk/generated/Gtk_Gradient.cs
@@ -99,7 +99,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_IconSet.cs
+++ b/Source/gtk/generated/Gtk_IconSet.cs
@@ -139,7 +139,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_IconSource.cs
+++ b/Source/gtk/generated/Gtk_IconSource.cs
@@ -240,7 +240,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_KineticScrolling.cs
+++ b/Source/gtk/generated/Gtk_KineticScrolling.cs
@@ -58,7 +58,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_MenuTracker.cs
+++ b/Source/gtk/generated/Gtk_MenuTracker.cs
@@ -65,7 +65,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_PaperSize.cs
+++ b/Source/gtk/generated/Gtk_PaperSize.cs
@@ -288,7 +288,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_RecentInfo.cs
+++ b/Source/gtk/generated/Gtk_RecentInfo.cs
@@ -317,7 +317,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_SelectionData.cs
+++ b/Source/gtk/generated/Gtk_SelectionData.cs
@@ -222,7 +222,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_SymbolicColor.cs
+++ b/Source/gtk/generated/Gtk_SymbolicColor.cs
@@ -138,7 +138,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_TargetList.cs
+++ b/Source/gtk/generated/Gtk_TargetList.cs
@@ -124,7 +124,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_TextAttributes.cs
+++ b/Source/gtk/generated/Gtk_TextAttributes.cs
@@ -375,7 +375,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_TreePath.cs
+++ b/Source/gtk/generated/Gtk_TreePath.cs
@@ -201,7 +201,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_TreeRowReference.cs
+++ b/Source/gtk/generated/Gtk_TreeRowReference.cs
@@ -136,7 +136,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/gtk/generated/Gtk_WidgetPath.cs
+++ b/Source/gtk/generated/Gtk_WidgetPath.cs
@@ -396,7 +396,11 @@ namespace Gtk {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_AttrIterator.cs
+++ b/Source/pango/generated/Pango_AttrIterator.cs
@@ -69,7 +69,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_AttrList.cs
+++ b/Source/pango/generated/Pango_AttrList.cs
@@ -107,7 +107,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_Coverage.cs
+++ b/Source/pango/generated/Pango_Coverage.cs
@@ -110,7 +110,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_FontDescription.cs
+++ b/Source/pango/generated/Pango_FontDescription.cs
@@ -323,7 +323,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_FontMetrics.cs
+++ b/Source/pango/generated/Pango_FontMetrics.cs
@@ -160,7 +160,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_GlyphString.cs
+++ b/Source/pango/generated/Pango_GlyphString.cs
@@ -157,7 +157,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_Item.cs
+++ b/Source/pango/generated/Pango_Item.cs
@@ -138,7 +138,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_LayoutIter.cs
+++ b/Source/pango/generated/Pango_LayoutIter.cs
@@ -259,7 +259,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_LayoutLine.cs
+++ b/Source/pango/generated/Pango_LayoutLine.cs
@@ -161,7 +161,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 

--- a/Source/pango/generated/Pango_TabArray.cs
+++ b/Source/pango/generated/Pango_TabArray.cs
@@ -117,7 +117,11 @@ namespace Pango {
 			if (!Owned)
 				return;
 			FinalizerInfo info = new FinalizerInfo (Handle);
-			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			if (ForceFinalizeInMainThread) {
+				GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
+			} else {
+				info.Handler();
+			}
 		}
 
 


### PR DESCRIPTION
Introduces global flag Opaque.ForceFinalizeInMainThread. When set to
false, objects inheriting Glib.Opaque will not schedule to conclude
their finalization from withing GLib main loop in the main thread, but
will do it immediately. This can be useful in programs that don't deal
with GTK widgets, which are expected to be freed from application's UI
thread.

For backward compatibility ForceFinalizeInMainThread defaults to true.