### PR TITLE
Fix finalizers implementation for Opaque subclasses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM base/devel
+FROM archlinux/archlinux:base-devel-20210627.0.27153
 
 RUN pacman -Syy --noconfirm
 RUN pacman -Syu --noconfirm


### PR DESCRIPTION
There was one finalizer being for level of inheritance.
For example Gst.Message -> Gst.MiniObject -> GLib.Opaque ends
with 2 finalizers being called, one calling gst_mini_object_unreg
another one calling gst_message_unref
The following implementation will only call once the unref function
for the highest class in the hierarchy

Fixes #54