### PR TITLE
Fix ownership of returned Opaque with GetOpaque

### DIFF
--- a/Source/glib/Opaque.cs
+++ b/Source/glib/Opaque.cs
@@ -39,18 +39,19 @@ namespace GLib {
 				return null;
 
 			Opaque opaque = (Opaque)Activator.CreateInstance (type, new object[] { o });
-			if (owned) {
-				if (opaque.owned) {
+			if (opaque.owned) {
 					// The constructor took a Ref it shouldn't have, so undo it
 					opaque.Unref (o);
-				}
+			}
+			if (owned) {
 				opaque.owned = true;
-			} else 
+			} else {
 				opaque = opaque.Copy (o);
+			}
 
 			return opaque;
   		}
-  
+
 		public Opaque ()
 		{
 			owned = true;


### PR DESCRIPTION
GetOpaque is returning Opaque objects with owner set to the opposite value as the one requested.
It seems like the existing fix was incorrectly applied to the wrong if branch.

This behaviour can be seen when overriding virtual methods like BaseSink.OnQuery that have as parameters Gst.MiniObject's and where GetOpaque is called with owned=false. 

The new Query object is owned and with an extra Ref, making it isWritable=false, while it should be !owned and with refcount of 1 to make it IsWritable=false