### PR TITLE
Fixed an incorrect variable name in the meson build file

### DIFF
--- a/Source/gio/generated/meson.build
+++ b/Source/gio/generated/meson.build
@@ -413,5 +413,5 @@ pkgs += [pkg]
 source_gen = files(generated_sources)
 gio_api_includes = join_paths(meson.current_source_dir(), 'gio-api.xml')
 if install
-    install_data(gdk_api_includes, install_dir: gapi_xml_installdir)
+    install_data(gio_api_includes, install_dir: gapi_xml_installdir)
 endif


### PR DESCRIPTION
I ran into a build error when building the default C# project in Gnome-Builder.  This change seems to fix it.  I'm no meson expert, though.