### PR TITLE
Fix installation path

### DIFF
--- a/Source/meson.build
+++ b/Source/meson.build
@@ -74,7 +74,7 @@ version_data.set('PACKAGE_VERSION', pkg_version)
 
 install_infos = []
 nuget_infos = []
-lib_install_dir = join_paths(get_option('libdir'), 'mono', pkg_version)
+lib_install_dir = join_paths(get_option('prefix'), 'lib', 'mono', pkg_version)
 pkg_install_dir = join_paths(get_option('libdir'), 'pkgconfig')
 gapi_xml_installdir = join_paths(get_option('datadir'), 'gapi-3.0')
 

--- a/Source/parser/meson.build
+++ b/Source/parser/meson.build
@@ -1,4 +1,4 @@
-gapi_installdir = join_paths(get_option('libdir'), 'gapi-3.0')
+gapi_installdir = join_paths(get_option('prefix'), 'lib', 'gapi-3.0')
 pkg_install_dir = '@0@/pkgconfig'.format(get_option('libdir'))
 
 gapi_parser = executable('gapi-parser', 'gapi-parser.cs',


### PR DESCRIPTION
According to Fedora Mono Packaging Guidelines [1], mono assemblies are not
architecture-specific.

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Mono/#_file_locations_and_architectures

Fixes issue #72.