### PR TITLE
Add a configuration to disable finalization on main thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         run: dotnet format Source/gtk-sharp.sln --verify-no-changes --no-restore
       - name: Install Deps
-        run: pip3 install meson ninja
+        run: pip3 install meson ninja --break-system-packages
       - name: Install Windows Deps
         if: matrix.config.os == 'windows-latest'
         run: choco install winflexbison3 pkgconfiglite -y --allow-empty-checksum

--- a/Source/glib/Object.cs
+++ b/Source/glib/Object.cs
@@ -8,7 +8,7 @@
 // Copyright (c) 2013 Andres G. Aragoneses
 //
 // This program is free software; you can redistribute it and/or
-// modify it under the terms of version 2 of the Lesser GNU General 
+// modify it under the terms of version 2 of the Lesser GNU General
 // Public License as published by the Free Software Foundation.
 //
 // This program is distributed in the hope that it will be useful,
@@ -66,7 +66,7 @@ namespace GLib {
 			if (tref == null)
 				return;
 
-			if (disposing)
+			if (disposing || !FinalizeOnMainThread)
 				tref.Dispose();
 			else
 				tref.QueueUnref();
@@ -75,6 +75,8 @@ namespace GLib {
 		public static explicit operator IntPtr(Object o) => o.Handle;
 
 		public static bool WarnOnFinalize { get; set; }
+
+		public static bool FinalizeOnMainThread { get; set; } = true;
 
 		[DllImport(Global.GObjectNativeDll, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr g_object_ref(IntPtr raw);

--- a/Source/glib/Opaque.cs
+++ b/Source/glib/Opaque.cs
@@ -130,8 +130,12 @@ namespace GLib {
 		protected virtual void DisposeUnmanagedResources() {
 			if (!Owned || DisposeUnmanagedFunc == null)
 				return;
-			FinalizerInfo info = new FinalizerInfo(DisposeUnmanagedFunc, Handle);
-			Timeout.Add(50, new TimeoutHandler(info.Handler));
+			if (Object.FinalizeOnMainThread) {
+				FinalizerInfo info = new FinalizerInfo(DisposeUnmanagedFunc, Handle);
+				Timeout.Add(50, new TimeoutHandler(info.Handler));
+			} else {
+				DisposeUnmanagedFunc(Handle);
+			}
 		}
 
 		protected internal bool Disposed { get; private set; } = false;


### PR DESCRIPTION
Some users of the bindings like GStreamer might not be running a main loop at all. This add a way to disable running the finalizers on the main thread.